### PR TITLE
Use bash explicitly in postinstall script

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "coffee-script": ">=1.0.1"
   },
   "scripts": {
-    "postinstall": "sh build-js.sh"
+    "postinstall": "bash build-js.sh"
   },
   "main": "js/document",
   "browserify": {


### PR DESCRIPTION
The postinstall script build-js.sh relies on Bashisms (e.g. "[[" test). Some distros (e.g. Ubuntu) have replaced sh with dash. Call bash explicitly since the script expects it.